### PR TITLE
Change mongo uri in app/middleware/mongoose.js

### DIFF
--- a/app/middleware/mongoose.js
+++ b/app/middleware/mongoose.js
@@ -4,7 +4,7 @@ const mongoose = require('mongoose');
 
 let uri;
 if (process.env.NODE_ENV === 'production') {
-  uri = process.env.MONGOLAB_URI;
+  uri = process.env.MONGODB_URI;
 } else {
   uri = 'mongodb://localhost/sweaters-for-turtles-api';
 }


### PR DESCRIPTION
Follow first steps in heroku node deployment guide fron issue 222.
Change uri from 'process.env.MONGOLAB_URI' to 'process.env.MONGODB_URI'
to reflect new mlab mongo database.
